### PR TITLE
Allow single line comment toggling

### DIFF
--- a/settings/language-forth.cson
+++ b/settings/language-forth.cson
@@ -1,0 +1,3 @@
+'.source.forth':
+  editor:
+    commentStart: '\\ '


### PR DESCRIPTION
By default my Atom would use `/*` when I did use the `line comment toggle` command which is not appropriate in Forth. There we need a `\` (escaped).